### PR TITLE
Sync master with dev. Fix #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ client_connection = ClientFactory.create_ntlm('username', 'userpassword', 'https
     
 4. Manage TFS items
 
-    4.1 Managing workitems
+    4.1 Get workitems properties
     ```python
     wi = workitem_client.get_single_workitem(100500)
     print('Item: Id={}, Title={}, State={}'.format(wi.id, wi.title, wi['System.State']))
@@ -47,6 +47,38 @@ client_connection = ClientFactory.create_ntlm('username', 'userpassword', 'https
     workitems = workitem_client.get_workitems([1, 2, 3])
     for wi in workitems:
         print('Item: id={}, Title={}'.format(wi.id, wi.title))
+    ```
+
+    4.2 Create workitem in current project
+    ```python
+    wi_type_name = 'Requirement'
+    wi_title = f'New requirement'
+    wi_description = f'This BRQ was created by PyTfsClient'
+
+    wi_fields = {
+        'System.Title': wi_title,
+        'System.Description': wi_description,
+    }
+
+    # Create workitem
+    wi = workitem_client.create_workitem(wi_type_name, wi_fields)
+    ```
+
+    4.3 Create workitem in another project
+    ```python
+    wi_project = f'AnotherProject'
+
+    wi_type_name = 'User Story'
+    wi_title = f'New user story'
+    wi_description = f'This User Story was created by PyTfsClient'
+
+    wi_fields = {
+        'System.Title': wi_title,
+        'System.Description': wi_description,
+    }
+
+    # Create workitem
+    wi = workitem_client.create_workitem(type_name=wi_type_name, item_fields=wi_fields, project=wi_project)
     ```
 
 # Coding style

--- a/src/pytfsclient/services/workitem_client/workitem_client.py
+++ b/src/pytfsclient/services/workitem_client/workitem_client.py
@@ -189,6 +189,7 @@ class WorkitemClient(BaseClient):
     
     def create_workitem(self, type_name: str, \
         item_fields: Dict[str, str] = None, item_relations: List[WorkitemRelation] = None, \
+        project: str = None, \
         expand: str = 'All', bypass_rules: bool = False, \
         suppress_notifications: bool = False, validate_only: bool = False) -> Workitem:
         '''
@@ -215,7 +216,10 @@ class WorkitemClient(BaseClient):
             raise ClientError('WorkitemClient::create_workitem: item type name can\'t be None')
 
         # request url
-        request_url = f'{self.client_connection.project_url}/{self._WORKITEM_URL}/${type_name}'
+        request_url = f'{self.client_connection.project_url}/{self._WORKITEM_URL}/${type_name}' \
+            if not project \
+            else f'{self.client_connection.collection}/{project}/_apis/{self._WORKITEM_URL}/${type_name}'
+        #request_url = f'{self.client_connection.project_url}/{self._WORKITEM_URL}/${type_name}'
 
         # query params
         query_params = WorkitemClient._make_query_params(expand, bypass_rules, suppress_notifications, validate_only)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -85,6 +85,32 @@ def test_create_workitem(workitem_client: WorkitemClient):
     assert wi, 'Can\'t create Workitem!'
     assert wi.title == wi_title, 'Workitem title differs!'
 
+def test_create_workitem_another_project(workitem_client: WorkitemClient):
+    # Arrange
+    today = datetime.date.today()
+    wi_type_name = 'User Story'
+    wi_title = f'[BRQ] New user story in another project - {today}'
+    wi_description = f'This BRQ was created by test at {today}'
+
+    wi_project = f'AnotherProject'
+    wi_area_path = f'AnotherProject'
+    wi_iteration_path = f'AnotherProject'
+
+    wi_fields = {
+        'System.Title': wi_title,
+        'System.Description': wi_description,
+        'System.AreaPath': wi_area_path,
+        'System.IterationPath': wi_iteration_path
+    }
+
+    # Act
+    wi = workitem_client.create_workitem(type_name=wi_type_name, item_fields=wi_fields, project=wi_project)
+    #wi = workitem_client.create_workitem(wi_type_name, wi_fields)
+
+    # Assert
+    assert wi, 'Can\'t create Workitem!'
+    assert wi.title == wi_title, 'Workitem title differs!'
+
 def test_create_child_tasks(workitem_client: WorkitemClient):
     # Arrange
     today = datetime.date.today()


### PR DESCRIPTION
Add ability to create workitem in another project
```python
    wi_project = f'AnotherProject'

    wi_type_name = 'User Story'
    wi_title = f'New user story'
    wi_description = f'This User Story was created by PyTfsClient'

    wi_fields = {
        'System.Title': wi_title,
        'System.Description': wi_description,
    }

    # Create workitem
    wi = workitem_client.create_workitem(type_name=wi_type_name, item_fields=wi_fields, project=wi_project)
    ```